### PR TITLE
Fix build input descriptions

### DIFF
--- a/build/action.yml
+++ b/build/action.yml
@@ -11,10 +11,10 @@ inputs:
   tag:
     description: "Override latest tag on function Docker image, takes 'sha' or 'branch'"
     default: 'sha'
-  buildLabel:
+  buildArg:
     description: "Add a build-arg for Docker (KEY=VALUE)"
     default: ''
-  buildArg:
+  buildLabel:
     description: "Add a label for Docker image (LABEL=VALUE)"
     default: ''
   buildOption:


### PR DESCRIPTION
Hi @LucasRoesler,

I'm currently looking into CI/CD for OpenFaaS functions and your actions seem to be spot-on when not being able to use OFC 👍 

Would you also publish them to the marketplace? This would not only make their usage more convenient, but also shorten some n*10 seconds from the build time since then the images don't need to be built on each execution, as far as I can see.